### PR TITLE
Add table of contents to articles

### DIFF
--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -3,6 +3,7 @@
 import { useInView } from 'framer-motion'
 import Link from 'next/link'
 import { useEffect, useRef } from 'react'
+import clsx from 'clsx'
 
 import { useSectionStore } from '@/components/SectionProvider'
 import { Tag } from '@/components/Tag'
@@ -84,6 +85,7 @@ export function Heading<Level extends 2 | 3>({
   let Component = `h${level}` as 'h2' | 'h3'
   let ref = useRef<HTMLHeadingElement>(null)
   let registerHeading = useSectionStore((s) => s.registerHeading)
+  let current = useSectionStore((s) => s.visibleSections[0])
 
   let inView = useInView(ref, {
     margin: `${remToPx(-3.5)}px 0px 0px 0px`,
@@ -101,7 +103,10 @@ export function Heading<Level extends 2 | 3>({
       <Eyebrow tag={tag} label={label} />
       <Component
         ref={ref}
-        className={tag || label ? 'mt-2 scroll-mt-32' : 'scroll-mt-24'}
+        className={clsx(
+          tag || label ? 'mt-2 scroll-mt-32' : 'scroll-mt-24',
+          current === props.id && 'text-emerald-500',
+        )}
         {...props}
       >
         {anchor ? (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import clsx from 'clsx'
-import { AnimatePresence, motion, useIsPresent } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useRef } from 'react'
 
 import { Button } from '@/components/Button'
 import { useIsInsideMobileNavigation } from '@/components/MobileNavigation'
-import { useSectionStore } from '@/components/SectionProvider'
 import { Tag } from '@/components/Tag'
 import { remToPx } from '@/lib/remToPx'
 import { CloseButton } from '@headlessui/react'
@@ -82,47 +81,6 @@ function NavLink({
   )
 }
 
-function VisibleSectionHighlight({
-  group,
-  pathname,
-}: {
-  group: NavGroup
-  pathname: string
-}) {
-  let [sections, visibleSections] = useInitialValue(
-    [
-      useSectionStore((s) => s.sections),
-      useSectionStore((s) => s.visibleSections),
-    ],
-    useIsInsideMobileNavigation(),
-  )
-
-  let isPresent = useIsPresent()
-  let firstVisibleSectionIndex = Math.max(
-    0,
-    [{ id: '_top' }, ...sections].findIndex(
-      (section) => section.id === visibleSections[0],
-    ),
-  )
-  let itemHeight = remToPx(2)
-  let height = isPresent
-    ? Math.max(1, visibleSections.length) * itemHeight
-    : itemHeight
-  let top =
-    group.links.findIndex((link) => link.href === pathname) * itemHeight +
-    firstVisibleSectionIndex * itemHeight
-
-  return (
-    <motion.div
-      layout
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1, transition: { delay: 0.2 } }}
-      exit={{ opacity: 0 }}
-      className="absolute inset-x-0 top-0 bg-zinc-800/2.5 will-change-transform dark:bg-white/2.5"
-      style={{ borderRadius: 8, height, top }}
-    />
-  )
-}
 
 function ActivePageMarker({
   group,
@@ -159,8 +117,8 @@ function NavigationGroup({
   // state, so that the state does not change during the close animation.
   // The state will still update when we re-open (re-render) the navigation.
   let isInsideMobileNavigation = useIsInsideMobileNavigation()
-  let [pathname, sections] = useInitialValue(
-    [usePathname(), useSectionStore((s) => s.sections)],
+  let pathname = useInitialValue(
+    usePathname(),
     isInsideMobileNavigation,
   )
 
@@ -176,11 +134,6 @@ function NavigationGroup({
         {group.title}
       </motion.h2>
       <div className="relative mt-3 pl-2">
-        <AnimatePresence initial={!isInsideMobileNavigation}>
-          {isActiveGroup && (
-            <VisibleSectionHighlight group={group} pathname={pathname} />
-          )}
-        </AnimatePresence>
         <motion.div
           layout
           className="absolute inset-y-0 left-2 w-px bg-zinc-900/10 dark:bg-white/5"
@@ -196,34 +149,7 @@ function NavigationGroup({
               <NavLink href={link.href} active={link.href === pathname}>
                 {link.title}
               </NavLink>
-              <AnimatePresence mode="popLayout" initial={false}>
-                {link.href === pathname && sections.length > 0 && (
-                  <motion.ul
-                    role="list"
-                    initial={{ opacity: 0 }}
-                    animate={{
-                      opacity: 1,
-                      transition: { delay: 0.1 },
-                    }}
-                    exit={{
-                      opacity: 0,
-                      transition: { duration: 0.15 },
-                    }}
-                  >
-                    {sections.map((section) => (
-                      <li key={section.id}>
-                        <NavLink
-                          href={`${link.href}#${section.id}`}
-                          tag={section.tag}
-                          isAnchorLink
-                        >
-                          {section.title}
-                        </NavLink>
-                      </li>
-                    ))}
-                  </motion.ul>
-                )}
-              </AnimatePresence>
+              {/* Anchor links are omitted in the sidebar */}
             </motion.li>
           ))}
         </ul>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -11,13 +11,28 @@ import { useIsInsideMobileNavigation } from '@/components/MobileNavigation'
 import { Tag } from '@/components/Tag'
 import { remToPx } from '@/lib/remToPx'
 import { CloseButton } from '@headlessui/react'
+import { BookIcon } from '@/components/icons/BookIcon'
+import { BoltIcon } from '@/components/icons/BoltIcon'
+import { SquaresPlusIcon } from '@/components/icons/SquaresPlusIcon'
+import { CheckIcon } from '@/components/icons/CheckIcon'
+import { ListIcon } from '@/components/icons/ListIcon'
+import { BellIcon } from '@/components/icons/BellIcon'
+import { LinkIcon } from '@/components/icons/LinkIcon'
+import { UserIcon } from '@/components/icons/UserIcon'
+import { ChatBubbleIcon } from '@/components/icons/ChatBubbleIcon'
+import { EnvelopeIcon } from '@/components/icons/EnvelopeIcon'
+import { UsersIcon } from '@/components/icons/UsersIcon'
+import { PaperClipIcon } from '@/components/icons/PaperClipIcon'
+
+interface NavItem {
+  title: string
+  href: string
+  icon: React.ComponentType<{ className?: string }>
+}
 
 interface NavGroup {
   title: string
-  links: Array<{
-    title: string
-    href: string
-  }>
+  links: Array<NavItem>
 }
 
 function useInitialValue<T>(value: T, condition = true) {
@@ -48,12 +63,14 @@ function TopLevelNavItem({
 function NavLink({
   href,
   children,
+  icon: Icon,
   tag,
   active = false,
   isAnchorLink = false,
 }: {
   href: string
   children: React.ReactNode
+  icon?: React.ComponentType<{ className?: string }>
   tag?: string
   active?: boolean
   isAnchorLink?: boolean
@@ -64,13 +81,14 @@ function NavLink({
       href={href}
       aria-current={active ? 'page' : undefined}
       className={clsx(
-        'flex justify-between gap-2 py-1 pr-3 text-sm transition',
+        'flex items-center justify-between gap-2 py-1 pr-3 text-sm transition',
         isAnchorLink ? 'pl-7' : 'pl-4',
         active
           ? 'text-zinc-900 dark:text-white'
           : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white',
       )}
     >
+      {Icon && <Icon className="h-4 w-4 flex-none" />}
       <span className="truncate">{children}</span>
       {tag && (
         <Tag variant="small" color="zinc">
@@ -134,19 +152,19 @@ function NavigationGroup({
         {group.title}
       </motion.h2>
       <div className="relative mt-3 pl-2">
-        <motion.div
-          layout
-          className="absolute inset-y-0 left-2 w-px bg-zinc-900/10 dark:bg-white/5"
-        />
         <AnimatePresence initial={false}>
           {isActiveGroup && (
             <ActivePageMarker group={group} pathname={pathname} />
           )}
         </AnimatePresence>
-        <ul role="list" className="border-l border-transparent">
+        <ul role="list">
           {group.links.map((link) => (
             <motion.li key={link.href} layout="position" className="relative">
-              <NavLink href={link.href} active={link.href === pathname}>
+              <NavLink
+                href={link.href}
+                icon={link.icon}
+                active={link.href === pathname}
+              >
                 {link.title}
               </NavLink>
               {/* Anchor links are omitted in the sidebar */}
@@ -162,23 +180,23 @@ export const navigation: Array<NavGroup> = [
   {
     title: 'Guides',
     links: [
-      { title: 'Introduction', href: '/' },
-      { title: 'Quickstart', href: '/quickstart' },
-      { title: 'SDKs', href: '/sdks' },
-      { title: 'Authentication', href: '/authentication' },
-      { title: 'Pagination', href: '/pagination' },
-      { title: 'Errors', href: '/errors' },
-      { title: 'Webhooks', href: '/webhooks' },
+      { title: 'Introduction', href: '/', icon: BookIcon },
+      { title: 'Quickstart', href: '/quickstart', icon: BoltIcon },
+      { title: 'SDKs', href: '/sdks', icon: SquaresPlusIcon },
+      { title: 'Authentication', href: '/authentication', icon: CheckIcon },
+      { title: 'Pagination', href: '/pagination', icon: ListIcon },
+      { title: 'Errors', href: '/errors', icon: BellIcon },
+      { title: 'Webhooks', href: '/webhooks', icon: LinkIcon },
     ],
   },
   {
     title: 'Resources',
     links: [
-      { title: 'Contacts', href: '/contacts' },
-      { title: 'Conversations', href: '/conversations' },
-      { title: 'Messages', href: '/messages' },
-      { title: 'Groups', href: '/groups' },
-      { title: 'Attachments', href: '/attachments' },
+      { title: 'Contacts', href: '/contacts', icon: UserIcon },
+      { title: 'Conversations', href: '/conversations', icon: ChatBubbleIcon },
+      { title: 'Messages', href: '/messages', icon: EnvelopeIcon },
+      { title: 'Groups', href: '/groups', icon: UsersIcon },
+      { title: 'Attachments', href: '/attachments', icon: PaperClipIcon },
     ],
   },
 ]

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -81,14 +81,23 @@ function NavLink({
       href={href}
       aria-current={active ? 'page' : undefined}
       className={clsx(
-        'flex items-center justify-between gap-2 py-1 pr-3 text-sm transition',
+        'group flex items-center gap-3 py-1 pr-3 text-sm transition',
         isAnchorLink ? 'pl-7' : 'pl-4',
         active
           ? 'text-zinc-900 dark:text-white'
           : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white',
       )}
     >
-      {Icon && <Icon className="h-4 w-4 flex-none" />}
+      {Icon && (
+        <Icon
+          className={clsx(
+            'h-5 w-5 flex-none',
+            active
+              ? 'stroke-emerald-500'
+              : 'stroke-zinc-400 group-hover:stroke-zinc-600 dark:stroke-zinc-500 dark:group-hover:stroke-zinc-300',
+          )}
+        />
+      )}
       <span className="truncate">{children}</span>
       {tag && (
         <Tag variant="small" color="zinc">

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -7,22 +7,23 @@ import { useSectionStore } from '@/components/SectionProvider'
 export function TableOfContents({ className }: { className?: string }) {
   let sections = useSectionStore((s) => s.sections)
   let visibleSections = useSectionStore((s) => s.visibleSections)
+  let current = visibleSections[0]
 
   if (sections.length === 0) {
     return null
   }
 
   return (
-    <nav className={clsx('text-sm leading-6', className)} aria-label="On this page">
-      <h2 className="font-semibold text-zinc-900 dark:text-white">On this page</h2>
-      <ul className="mt-4 space-y-3">
+    <nav className={clsx('text-sm leading-6', className)} aria-label="目次">
+      <h2 className="font-semibold text-zinc-900 dark:text-white">目次</h2>
+      <ul className="mt-4 space-y-3 border-l border-zinc-200 pl-3 dark:border-zinc-700">
         {sections.map((section) => (
           <li key={section.id}>
             <Link
               href={`#${section.id}`}
               className={clsx(
-                'block hover:text-emerald-500',
-                visibleSections.includes(section.id)
+                'block -ml-1 hover:text-emerald-500',
+                section.id === current
                   ? 'text-emerald-500'
                   : 'text-zinc-700 dark:text-zinc-300'
               )}

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -15,14 +15,13 @@ export function TableOfContents({ className }: { className?: string }) {
 
   return (
     <nav className={clsx('text-sm leading-6', className)} aria-label="目次">
-      <h2 className="font-semibold text-zinc-900 dark:text-white">目次</h2>
-      <ul className="mt-4 space-y-3 border-l border-zinc-200 pl-3 dark:border-zinc-700">
+      <ul className="mt-4 space-y-3 border-l border-zinc-200 pl-4 dark:border-zinc-700">
         {sections.map((section) => (
           <li key={section.id}>
             <Link
               href={`#${section.id}`}
               className={clsx(
-                'block -ml-1 hover:text-emerald-500',
+                'block hover:text-emerald-500',
                 section.id === current
                   ? 'text-emerald-500'
                   : 'text-zinc-700 dark:text-zinc-300'

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import clsx from 'clsx'
+import Link from 'next/link'
+import { useSectionStore } from '@/components/SectionProvider'
+
+export function TableOfContents({ className }: { className?: string }) {
+  let sections = useSectionStore((s) => s.sections)
+  let visibleSections = useSectionStore((s) => s.visibleSections)
+
+  if (sections.length === 0) {
+    return null
+  }
+
+  return (
+    <nav className={clsx('text-sm leading-6', className)} aria-label="On this page">
+      <h2 className="font-semibold text-zinc-900 dark:text-white">On this page</h2>
+      <ul className="mt-4 space-y-3">
+        {sections.map((section) => (
+          <li key={section.id}>
+            <Link
+              href={`#${section.id}`}
+              className={clsx(
+                'block hover:text-emerald-500',
+                visibleSections.includes(section.id)
+                  ? 'text-emerald-500'
+                  : 'text-zinc-700 dark:text-zinc-300'
+              )}
+            >
+              {section.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { Feedback } from '@/components/Feedback'
 import { Heading } from '@/components/Heading'
 import { Prose } from '@/components/Prose'
+import { TableOfContents } from '@/components/TableOfContents'
 
 export const a = Link
 export { Button } from '@/components/Button'
@@ -11,11 +12,16 @@ export { CodeGroup, Code as code, Pre as pre } from '@/components/Code'
 
 export function wrapper({ children }: { children: React.ReactNode }) {
   return (
-    <article className="flex h-full flex-col pt-16 pb-10">
-      <Prose className="flex-auto">{children}</Prose>
-      <footer className="mx-auto mt-16 w-full max-w-2xl lg:max-w-5xl">
-        <Feedback />
-      </footer>
+    <article className="flex h-full flex-col pt-16 pb-10 lg:flex-row lg:items-start lg:gap-10">
+      <div className="min-w-0 flex-auto">
+        <Prose className="flex-auto">{children}</Prose>
+        <footer className="mx-auto mt-16 w-full max-w-2xl lg:max-w-5xl">
+          <Feedback />
+        </footer>
+      </div>
+      <div className="hidden lg:block lg:w-56 xl:w-64 flex-none">
+        <TableOfContents className="sticky top-24" />
+      </div>
     </article>
   )
 }

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -20,7 +20,7 @@ export function wrapper({ children }: { children: React.ReactNode }) {
         </footer>
       </div>
       <TableOfContents
-        className="fixed right-12 top-14 hidden w-56 overflow-y-auto lg:block xl:right-16 xl:w-64 max-h-[calc(100vh-3.5rem)]"
+        className="fixed right-16 top-14 hidden w-56 overflow-y-auto lg:block xl:right-20 xl:w-64 max-h-[calc(100vh-3.5rem)]"
       />
     </article>
   )

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -20,7 +20,7 @@ export function wrapper({ children }: { children: React.ReactNode }) {
         </footer>
       </div>
       <TableOfContents
-        className="fixed right-8 top-14 hidden w-56 overflow-y-auto lg:block xl:right-12 xl:w-64 max-h-[calc(100vh-3.5rem)]"
+        className="fixed right-12 top-14 hidden w-56 overflow-y-auto lg:block xl:right-16 xl:w-64 max-h-[calc(100vh-3.5rem)]"
       />
     </article>
   )

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -13,14 +13,14 @@ export { CodeGroup, Code as code, Pre as pre } from '@/components/Code'
 export function wrapper({ children }: { children: React.ReactNode }) {
   return (
     <article className="relative flex h-full flex-col pt-16 pb-10">
-      <div className="min-w-0 flex-auto lg:pr-60 xl:pr-72">
+      <div className="min-w-0 flex-auto lg:pr-64 xl:pr-80">
         <Prose className="flex-auto">{children}</Prose>
         <footer className="mx-auto mt-16 w-full max-w-2xl lg:max-w-5xl">
           <Feedback />
         </footer>
       </div>
       <TableOfContents
-        className="fixed right-16 top-14 hidden w-56 overflow-y-auto lg:block xl:right-20 xl:w-64 max-h-[calc(100vh-3.5rem)]"
+        className="fixed right-20 top-14 hidden w-56 overflow-y-auto lg:block xl:right-24 xl:w-64 max-h-[calc(100vh-3.5rem)]"
       />
     </article>
   )

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -12,16 +12,16 @@ export { CodeGroup, Code as code, Pre as pre } from '@/components/Code'
 
 export function wrapper({ children }: { children: React.ReactNode }) {
   return (
-    <article className="flex h-full flex-col pt-16 pb-10 lg:flex-row lg:items-start lg:gap-10">
-      <div className="min-w-0 flex-auto">
+    <article className="relative flex h-full flex-col pt-16 pb-10">
+      <div className="min-w-0 flex-auto lg:pr-56 xl:pr-64">
         <Prose className="flex-auto">{children}</Prose>
         <footer className="mx-auto mt-16 w-full max-w-2xl lg:max-w-5xl">
           <Feedback />
         </footer>
       </div>
-      <div className="hidden lg:block lg:w-56 xl:w-64 flex-none">
-        <TableOfContents className="sticky top-14" />
-      </div>
+      <TableOfContents
+        className="fixed right-8 top-14 hidden w-56 overflow-y-auto lg:block xl:right-12 xl:w-64 max-h-[calc(100vh-3.5rem)]"
+      />
     </article>
   )
 }

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -13,7 +13,7 @@ export { CodeGroup, Code as code, Pre as pre } from '@/components/Code'
 export function wrapper({ children }: { children: React.ReactNode }) {
   return (
     <article className="relative flex h-full flex-col pt-16 pb-10">
-      <div className="min-w-0 flex-auto lg:pr-56 xl:pr-64">
+      <div className="min-w-0 flex-auto lg:pr-60 xl:pr-72">
         <Prose className="flex-auto">{children}</Prose>
         <footer className="mx-auto mt-16 w-full max-w-2xl lg:max-w-5xl">
           <Feedback />

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -20,7 +20,7 @@ export function wrapper({ children }: { children: React.ReactNode }) {
         </footer>
       </div>
       <div className="hidden lg:block lg:w-56 xl:w-64 flex-none">
-        <TableOfContents className="sticky top-24" />
+        <TableOfContents className="sticky top-14" />
       </div>
     </article>
   )


### PR DESCRIPTION
## Summary
- create `TableOfContents` component using SectionProvider
- include the new component in MDX wrapper so docs pages show a sticky TOC

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5a6a717c832e8d790c24918be60b