### PR TITLE
Add docs tags and unify media posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-config-next": "^14.0.4",
     "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.6.11",
-    "sharp": "0.33.1"
+    "sharp": "0.33.1",
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
     '@tailwindcss/postcss': {},
+    autoprefixer: {},
   },
 }

--- a/src/app/docs/attachments/page.mdx
+++ b/src/app/docs/attachments/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Attachments',
   description:
     'On this page, we’ll dive into the different attachment endpoints you can use to manage attachments programmatically.',
+  tags: ['docs', 'reference'],
 }
 
 Attachments are how you share things in Protocol — they allow you to send all sorts of files to your contacts and groups. On this page, we'll dive into the different attachment endpoints you can use to manage attachments programmatically. We'll look at how to query, upload, update, and delete attachments. {{ className: 'lead' }}

--- a/src/app/docs/audit-log/page.tsx
+++ b/src/app/docs/audit-log/page.tsx
@@ -4,6 +4,7 @@ import { Heading } from '@/components/Heading'
 export const metadata = {
   title: 'Audit log',
   description: 'Example page demonstrating breadcrumb and 2-column layout.',
+  tags: ['docs', 'guide'],
 }
 
 export const sections = [

--- a/src/app/docs/authentication/page.mdx
+++ b/src/app/docs/authentication/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Authentication',
   description:
     'In this guide, we’ll look at how authentication works. Protocol offers two ways to authenticate your API requests: Basic authentication and OAuth2 with a token.',
+  tags: ['docs', 'guide', 'auth'],
 }
 
 

--- a/src/app/docs/contacts/page.mdx
+++ b/src/app/docs/contacts/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Contacts',
   description:
     'On this page, we’ll dive into the different contact endpoints you can use to manage contacts programmatically.',
+  tags: ['docs', 'reference'],
 }
 
 

--- a/src/app/docs/conversations/page.mdx
+++ b/src/app/docs/conversations/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Conversations',
   description:
     'On this page, we’ll dive into the different conversation endpoints you can use to manage conversations programmatically.',
+  tags: ['docs', 'reference'],
 }
 
 

--- a/src/app/docs/errors/page.mdx
+++ b/src/app/docs/errors/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Errors',
   description:
     'In this guide, we will talk about what happens when something goes wrong while you work with the API.',
+  tags: ['docs', 'guide'],
 }
 
 

--- a/src/app/docs/groups/page.mdx
+++ b/src/app/docs/groups/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Groups',
   description:
     'On this page, we’ll dive into the different group endpoints you can use to manage groups programmatically.',
+  tags: ['docs', 'reference'],
 }
 
 

--- a/src/app/docs/messages/page.mdx
+++ b/src/app/docs/messages/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Messages',
   description:
     'On this page, we’ll dive into the different message endpoints you can use to manage messages programmatically.',
+  tags: ['docs', 'reference'],
 }
 
 

--- a/src/app/docs/page.mdx
+++ b/src/app/docs/page.mdx
@@ -6,6 +6,7 @@ export const metadata = {
   title: 'API Documentation',
   description:
     'Learn everything there is to know about the Protocol API and integrate Protocol into your product.',
+  tags: ['docs'],
 }
 
 export const sections = [

--- a/src/app/docs/pagination/page.mdx
+++ b/src/app/docs/pagination/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Pagination',
   description:
     'In this guide, we will look at how to work with paginated responses when querying the Protocol API',
+  tags: ['docs', 'guide'],
 }
 
 

--- a/src/app/docs/quickstart/page.mdx
+++ b/src/app/docs/quickstart/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Quickstart',
   description:
     'This guide will get you all set up and ready to use the Protocol API. We’ll cover how to get started an API client and how to make your first API request.',
+  tags: ['docs', 'guide'],
 }
 
 

--- a/src/app/docs/sdks/page.mdx
+++ b/src/app/docs/sdks/page.mdx
@@ -4,6 +4,7 @@ export const metadata = {
   title: 'Protocol SDKs',
   description:
     'Protocol offers fine-tuned JavaScript, Ruby, PHP, Python, and Go libraries to make your life easier and give you the best experience when consuming the API.',
+  tags: ['docs', 'guide'],
 }
 
 export const sections = [

--- a/src/app/docs/webhooks/page.mdx
+++ b/src/app/docs/webhooks/page.mdx
@@ -2,6 +2,7 @@ export const metadata = {
   title: 'Webhooks',
   description:
     'In this guide, we will look at how to register and consume webhooks to integrate your app with Protocol.',
+  tags: ['docs', 'guide'],
 }
 
 

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -27,7 +27,18 @@ export async function getMediaPosts(): Promise<MediaPost[]> {
     }),
   )
 
-  let posts = [...blogPosts]
+  let docFiles = await glob('*/page.{mdx,tsx}', { cwd: 'src/app/docs' })
+  let docPosts = await Promise.all(
+    docFiles.map(async (file) => {
+      let mod = await import(`../app/docs/${file}`)
+      return {
+        slug: `/docs/${file.replace(/\/page\.(mdx|tsx)$/, '')}`,
+        metadata: mod.metadata as MediaMeta,
+        type: 'docs',
+      }
+    }),
+  )
+  let posts = [...blogPosts, ...docPosts]
 
   posts.sort((a, b) => {
     let da = a.metadata.date ? new Date(a.metadata.date).getTime() : 0


### PR DESCRIPTION
## Summary
- add `tags` metadata to all docs pages
- extend `getMediaPosts` to include docs entries

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c81cace74832ea671b2329b94e129