### PR TITLE
Improve blog page styling

### DIFF
--- a/src/app/blog/page.mdx
+++ b/src/app/blog/page.mdx
@@ -1,12 +1,16 @@
 import { BlogList } from '@/components/BlogList'
+import { HeroPattern } from '@/components/HeroPattern'
 
 export const metadata = {
   title: 'Blog',
   description: '最新情報やアップデートをお届けします。',
 }
 
-# Blog
 
-最新の記事一覧です。
+<div className="relative mb-12 overflow-hidden rounded-xl bg-gradient-to-r from-emerald-500 to-lime-400 p-8 text-center text-white shadow-lg not-prose">
+  <HeroPattern />
+  <h1 className="relative z-10 text-3xl font-bold">Blog</h1>
+  <p className="relative z-10 mt-2">最新の記事一覧です。</p>
+</div>
 
 <BlogList />

--- a/src/components/BlogListClient.tsx
+++ b/src/components/BlogListClient.tsx
@@ -68,7 +68,7 @@ export function BlogListInner({
         {visible.map((post) => (
           <article
             key={post.slug}
-            className="group overflow-hidden rounded-lg shadow-md transition hover:shadow-lg"
+            className="group overflow-hidden rounded-xl border border-zinc-200 bg-white shadow transition hover:shadow-lg hover:ring-1 hover:ring-emerald-400 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:ring-emerald-500"
           >
             {post.metadata.image && (
               <Link href={post.slug} className="block overflow-hidden">
@@ -76,7 +76,7 @@ export function BlogListInner({
                 <img
                   src={post.metadata.image}
                   alt=""
-                  className="h-48 w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                  className="h-48 w-full rounded-t-xl object-cover transition-transform duration-300 group-hover:scale-105"
                 />
               </Link>
             )}
@@ -86,7 +86,7 @@ export function BlogListInner({
                   <Link
                     href={`/tags/${tag}`}
                     key={tag}
-                    className="rounded-full bg-gray-100 px-2 py-0.5 text-sm text-gray-700 dark:bg-zinc-800 dark:text-zinc-200"
+                    className="rounded-full bg-gray-100 px-2 py-0.5 text-sm text-gray-700 transition-colors hover:bg-gray-200 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
                   >
                     {tag}
                   </Link>


### PR DESCRIPTION
## Summary
- add gradient hero section to the blog page
- style blog post cards with nicer hover effects

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6860f04aed5c832eb6dc591d02caedc7