### PR TITLE
Add common header and new site pages

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,11 +1,11 @@
 export const metadata = {
-  title: 'Home',
+  title: 'Contact',
 }
 
-export default function HomePage() {
+export default function ContactPage() {
   return (
     <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-      <h1 className="text-3xl font-bold">Welcome to Protocol</h1>
+      <h1 className="text-3xl font-bold">Contact</h1>
     </div>
   )
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,8 +4,174 @@ export const metadata = {
 
 export default function ContactPage() {
   return (
-    <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-      <h1 className="text-3xl font-bold">Contact</h1>
+    <div className="isolate bg-white px-6 py-24 sm:py-32 lg:px-8">
+      <div
+        className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
+        aria-hidden="true"
+      >
+        <div
+          className="relative left-1/2 -z-10 aspect-1155/678 w-144.5 max-w-none -translate-x-1/2 rotate-30 bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-30 sm:left-[calc(50%-40rem)] sm:w-288.75"
+          style={{
+            clipPath:
+              'polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)',
+          }}
+        />
+      </div>
+      <div className="mx-auto max-w-2xl text-center">
+        <h2 className="text-4xl font-semibold tracking-tight text-balance text-gray-900 sm:text-5xl">
+          Contact sales
+        </h2>
+        <p className="mt-2 text-lg/8 text-gray-600">
+          Aute magna irure deserunt veniam aliqua magna enim voluptate.
+        </p>
+      </div>
+      <form action="#" method="POST" className="mx-auto mt-16 max-w-xl sm:mt-20">
+        <div className="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-2">
+          <div>
+            <label htmlFor="first-name" className="block text-sm/6 font-semibold text-gray-900">
+              First name
+            </label>
+            <div className="mt-2.5">
+              <input
+                type="text"
+                name="first-name"
+                id="first-name"
+                autoComplete="given-name"
+                className="block w-full rounded-md bg-white px-3.5 py-2 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600"
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="last-name" className="block text-sm/6 font-semibold text-gray-900">
+              Last name
+            </label>
+            <div className="mt-2.5">
+              <input
+                type="text"
+                name="last-name"
+                id="last-name"
+                autoComplete="family-name"
+                className="block w-full rounded-md bg-white px-3.5 py-2 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600"
+              />
+            </div>
+          </div>
+          <div className="sm:col-span-2">
+            <label htmlFor="company" className="block text-sm/6 font-semibold text-gray-900">
+              Company
+            </label>
+            <div className="mt-2.5">
+              <input
+                type="text"
+                name="company"
+                id="company"
+                autoComplete="organization"
+                className="block w-full rounded-md bg-white px-3.5 py-2 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600"
+              />
+            </div>
+          </div>
+          <div className="sm:col-span-2">
+            <label htmlFor="email" className="block text-sm/6 font-semibold text-gray-900">
+              Email
+            </label>
+            <div className="mt-2.5">
+              <input
+                type="email"
+                name="email"
+                id="email"
+                autoComplete="email"
+                className="block w-full rounded-md bg-white px-3.5 py-2 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600"
+              />
+            </div>
+          </div>
+          <div className="sm:col-span-2">
+            <label htmlFor="phone-number" className="block text-sm/6 font-semibold text-gray-900">
+              Phone number
+            </label>
+            <div className="mt-2.5">
+              <div className="flex rounded-md bg-white outline-1 -outline-offset-1 outline-gray-300 has-[input:focus-within]:outline-2 has-[input:focus-within]:-outline-offset-2 has-[input:focus-within]:outline-indigo-600">
+                <div className="grid shrink-0 grid-cols-1 focus-within:relative">
+                  <select
+                    id="country"
+                    name="country"
+                    autoComplete="country"
+                    aria-label="Country"
+                    className="col-start-1 row-start-1 w-full appearance-none rounded-md py-2 pr-7 pl-3.5 text-base text-gray-500 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
+                  >
+                    <option>US</option>
+                    <option>CA</option>
+                    <option>EU</option>
+                  </select>
+                  <svg
+                    className="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-gray-500 sm:size-4"
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                    aria-hidden="true"
+                    data-slot="icon"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <input
+                  type="text"
+                  name="phone-number"
+                  id="phone-number"
+                  className="block min-w-0 grow py-1.5 pr-3 pl-1 text-base text-gray-900 placeholder:text-gray-400 focus:outline-none sm:text-sm/6"
+                  placeholder="123-456-7890"
+                />
+              </div>
+            </div>
+          </div>
+          <div className="sm:col-span-2">
+            <label htmlFor="message" className="block text-sm/6 font-semibold text-gray-900">
+              Message
+            </label>
+            <div className="mt-2.5">
+              <textarea
+                name="message"
+                id="message"
+                rows={4}
+                className="block w-full rounded-md bg-white px-3.5 py-2 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600"
+              />
+            </div>
+          </div>
+          <div className="flex gap-x-4 sm:col-span-2">
+            <div className="flex h-6 items-center">
+              <button
+                type="button"
+                className="flex w-8 flex-none cursor-pointer rounded-full bg-gray-200 p-px ring-1 ring-gray-900/5 transition-colors duration-200 ease-in-out ring-inset focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                role="switch"
+                aria-checked="false"
+                aria-labelledby="switch-1-label"
+              >
+                <span className="sr-only">Agree to policies</span>
+                <span
+                  aria-hidden="true"
+                  className="size-4 translate-x-0 transform rounded-full bg-white shadow-xs ring-1 ring-gray-900/5 transition duration-200 ease-in-out"
+                />
+              </button>
+            </div>
+            <label className="text-sm/6 text-gray-600" id="switch-1-label">
+              By selecting this, you agree to our{' '}
+              <a href="#" className="font-semibold whitespace-nowrap text-indigo-600">
+                privacy policy
+              </a>
+              .
+            </label>
+          </div>
+        </div>
+        <div className="mt-10">
+          <button
+            type="submit"
+            className="block w-full rounded-md bg-indigo-600 px-3.5 py-2.5 text-center text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+          >
+            Let's talk
+          </button>
+        </div>
+      </form>
     </div>
   )
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,11 +1,11 @@
 export const metadata = {
-  title: 'Home',
+  title: 'Pricing',
 }
 
-export default function HomePage() {
+export default function PricingPage() {
   return (
     <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-      <h1 className="text-3xl font-bold">Welcome to Protocol</h1>
+      <h1 className="text-3xl font-bold">Pricing</h1>
     </div>
   )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -74,7 +74,7 @@ export const Header = forwardRef<
       <Search />
       <div className="flex items-center gap-5 lg:hidden">
         <MobileNavigation />
-        <CloseButton as={Link} href="/docs" aria-label="Home">
+        <CloseButton as={Link} href="/" aria-label="Home">
           <Logo className="h-6" />
         </CloseButton>
       </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -43,7 +43,7 @@ export function Layout({
         >
           <div className="contents lg:pointer-events-auto lg:block lg:w-72 lg:overflow-y-auto lg:border-r lg:border-zinc-900/10 lg:px-6 lg:pt-4 lg:pb-8 xl:w-80 lg:dark:border-white/10">
             <div className="hidden lg:flex">
-              <Link href="/docs" aria-label="Home">
+              <Link href="/" aria-label="Home">
                 <Logo className="h-6" />
               </Link>
             </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,37 +9,8 @@ import { Header } from '@/components/Header'
 import { Logo } from '@/components/Logo'
 import { Navigation } from '@/components/Navigation'
 import { SectionProvider, type Section } from '@/components/SectionProvider'
+import { SiteHeader } from '@/components/SiteHeader'
 
-function BlogHeader() {
-  return (
-    <header className="bg-white shadow-sm dark:bg-zinc-900 dark:shadow-zinc-800/10">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex h-16 items-center justify-between">
-          <div className="flex items-center">
-            <Link href="/" className="flex items-center space-x-2">
-              <Logo className="h-8 w-auto" />
-              <span className="text-xl font-bold text-gray-900 dark:text-white">Protocol</span>
-            </Link>
-          </div>
-          <nav className="hidden space-x-8 md:flex">
-            <Link 
-              href="/docs" 
-              className="text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >
-              Documentation
-            </Link>
-            <Link 
-              href="/blog" 
-              className="text-emerald-600 font-medium dark:text-emerald-400"
-            >
-              Blog
-            </Link>
-          </nav>
-        </div>
-      </div>
-    </header>
-  )
-}
 
 export function Layout({
   children,
@@ -49,17 +20,14 @@ export function Layout({
   allSections: Record<string, Array<Section>>
 }) {
   let pathname = usePathname()
-  let isBlogPage = pathname?.startsWith('/blog')
+  let isDocsPage = pathname?.startsWith('/docs')
 
-  // Blog pages use a different layout
-  if (isBlogPage) {
+  if (!isDocsPage) {
     return (
       <SectionProvider sections={[]}>
         <div className="flex min-h-screen flex-col">
-          <BlogHeader />
-          <main className="flex-1">
-            {children}
-          </main>
+          <SiteHeader />
+          <main className="flex-1">{children}</main>
         </div>
       </SectionProvider>
     )

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -5,7 +5,7 @@ import { Logo } from '@/components/Logo'
 
 export function SiteHeader() {
   return (
-    <header className="bg-white shadow-sm dark:bg-zinc-900 dark:shadow-zinc-800/10">
+    <header className="sticky top-0 z-20 bg-white shadow-sm dark:bg-zinc-900 dark:shadow-zinc-800/10">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
           <Link href="/" className="flex items-center space-x-2">

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+import { Button } from '@/components/Button'
+import { Logo } from '@/components/Logo'
+
+export function SiteHeader() {
+  return (
+    <header className="bg-white shadow-sm dark:bg-zinc-900 dark:shadow-zinc-800/10">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          <Link href="/" className="flex items-center space-x-2">
+            <Logo className="h-8 w-auto" />
+            <span className="text-xl font-bold text-gray-900 dark:text-white">Protocol</span>
+          </Link>
+          <nav className="hidden space-x-8 md:flex">
+            <Link href="/pricing" className="text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">Pricing</Link>
+            <Link href="/docs" className="text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">Docs</Link>
+            <Link href="/blog" className="text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">Blog</Link>
+            <Link href="/contact" className="text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">Contact</Link>
+          </nav>
+          <div className="hidden space-x-4 md:flex">
+            <Button href="/auth/login" variant="secondary">Log in</Button>
+            <Button href="/auth/signup">Sign up</Button>
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add simple Home, Pricing and Contact pages
- implement a shared `SiteHeader` with links to main sections
- update layout to use `SiteHeader` for all non-docs pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620176bad8832e8564e89cf70aa039